### PR TITLE
feat(statblock): add StatBlock and tie gold income to DPS

### DIFF
--- a/Assets/Scripts/Combat/CombatSimulator.cs
+++ b/Assets/Scripts/Combat/CombatSimulator.cs
@@ -3,11 +3,13 @@ using UnityEngine;
 public class CombatSimulator : MonoBehaviour {
     [Header("Tuning")]
     public double GoldPerSecondBase = 1.0;
+    public double GoldPerDamage = 0.1;
     public int FullRateHoursCap = 8;
     public double PostCapMultiplier = 0.5;
 
     private double _goldBuffer;
     private SaveData _save;
+    private StatBlock _stats = new StatBlock { STR = 10, DEX = 10, CRIT = 0.1, ATKSPD = 1.0 };
 
     void OnEnable() {
         _save = SaveService.LoadOrNew();
@@ -24,8 +26,8 @@ public class CombatSimulator : MonoBehaviour {
     }
 
     void HandleTick(float dt) {
-        // TODO: replace with actual DPS/clear logic; placeholder uses a flat GPS.
-        double gps = GoldPerSecondBase;
+        double dps = _stats.ComputeDPS();
+        double gps = dps * GoldPerDamage;
         _goldBuffer += gps * dt;
         if (_goldBuffer >= 1.0) {
             var whole = (long)_goldBuffer;

--- a/Assets/Scripts/Stats.meta
+++ b/Assets/Scripts/Stats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a72518889974087bf1853c346e42e7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Stats/StatBlock.cs
+++ b/Assets/Scripts/Stats/StatBlock.cs
@@ -1,0 +1,14 @@
+using System;
+
+public class StatBlock {
+    public double STR;
+    public double DEX;
+    public double CRIT;
+    public double ATKSPD;
+
+    public double ComputeDPS() {
+        double baseDamage = 5.0 + STR * 0.5 + DEX * 0.25;
+        double critMult = 1.0 + CRIT;
+        return baseDamage * ATKSPD * critMult;
+    }
+}

--- a/Assets/Scripts/Stats/StatBlock.cs.meta
+++ b/Assets/Scripts/Stats/StatBlock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cba2d431eb8b4071939e72da76093c4e


### PR DESCRIPTION
## Summary
- add StatBlock with STR, DEX, CRIT, ATKSPD and ComputeDPS
- drive gold income from DPS via GoldPerDamage multiplier

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b44a18a48327a346545ed77f37e1