### PR TITLE
feat: add runtime loadout UI and stats readout

### DIFF
--- a/Assets/Scripts/Combat/CombatSimulator.cs
+++ b/Assets/Scripts/Combat/CombatSimulator.cs
@@ -99,7 +99,7 @@ public class CombatSimulator : MonoBehaviour
 
     // --- helpers for UI/Debug ---
     public double GetGold() => _save?.gold ?? 0;
-    public float DebugDPS() => (float)((finalStats ?? baseStats).ComputeDPS());
+    public float DebugDPS() => (float)((finalStats ?? baseStats).ComputeDPS()); // used by UI
 
     // Called by UI when equipment changes later
     public void RecomputeStats(Loadout l)

--- a/Assets/Scripts/Items/ItemCatalog.cs
+++ b/Assets/Scripts/Items/ItemCatalog.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(menuName = "IdleRPG/ItemCatalog")]
+public class ItemCatalog : ScriptableObject
+{
+    public ItemDef[] AllItems;
+
+    public ItemDef[] ForSlot(ItemSlot slot)
+    {
+        if (AllItems == null || AllItems.Length == 0)
+            return new ItemDef[0];
+
+        var list = new List<ItemDef>();
+        foreach (var item in AllItems)
+        {
+            if (item && item.Slot == slot)
+                list.Add(item);
+        }
+        return list.ToArray();
+    }
+}

--- a/Assets/Scripts/Items/ItemCatalog.cs.meta
+++ b/Assets/Scripts/Items/ItemCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f7fc7e554f84979a00d19c97029497a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/GoldHud.cs
+++ b/Assets/Scripts/UI/GoldHud.cs
@@ -7,7 +7,8 @@ public class GoldHud : MonoBehaviour {
 
     void Update() {
         if (Simulator && GoldText) {
-            GoldText.text = $"Gold: {Simulator.GetGold():N0}";
+            var dps = Simulator.DebugDPS();
+            GoldText.text = $"Gold: {Simulator.GetGold():N0}\nDPS: {dps:F1}\nGPS: {dps * Simulator.goldPerDamage:F2}";
         }
     }
 }

--- a/Assets/Scripts/UI/LoadoutUI.cs
+++ b/Assets/Scripts/UI/LoadoutUI.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class LoadoutUI : MonoBehaviour
+{
+    public ItemCatalog catalog;
+    public LoadoutPresenter presenter;
+    public CombatSimulator simulator;
+    public RectTransform root;
+    public TextMeshProUGUI header;
+
+    private readonly Dictionary<ItemSlot, TextMeshProUGUI> _sectionHeaders = new Dictionary<ItemSlot, TextMeshProUGUI>();
+
+    void Start()
+    {
+        if (!catalog)
+            catalog = Resources.Load<ItemCatalog>("ItemCatalog");
+        if (!catalog)
+        {
+            var canvas = EnsureCanvas();
+            var label = new GameObject("NoCatalog", typeof(TextMeshProUGUI));
+            label.transform.SetParent(canvas.transform, false);
+            label.GetComponent<TextMeshProUGUI>().text = "No ItemCatalog assigned";
+            return;
+        }
+
+        var c = EnsureCanvas();
+        if (!root)
+        {
+            var panel = new GameObject("LoadoutPanel", typeof(RectTransform), typeof(Image), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            panel.transform.SetParent(c.transform, false);
+            var img = panel.GetComponent<Image>();
+            img.color = new Color(0, 0, 0, 0.25f);
+            var vg = panel.GetComponent<VerticalLayoutGroup>();
+            vg.padding = new RectOffset(10, 10, 10, 10);
+            vg.spacing = 4;
+            vg.childControlWidth = true;
+            vg.childForceExpandWidth = true;
+            var fitter = panel.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            root = panel.GetComponent<RectTransform>();
+        }
+
+        if (header)
+            header.text = "Loadout";
+
+        BuildSection(ItemSlot.Head, "Head");
+        BuildSection(ItemSlot.Body, "Body");
+        BuildSection(ItemSlot.Weapon, "Weapon");
+        BuildSection(ItemSlot.Offhand, "Offhand");
+
+        var current = LoadoutStorage.Load();
+        UpdateHeader(ItemSlot.Head, current.Head);
+        UpdateHeader(ItemSlot.Body, current.Body);
+        UpdateHeader(ItemSlot.Weapon, current.Weapon);
+        UpdateHeader(ItemSlot.Offhand, current.Offhand);
+    }
+
+    Canvas EnsureCanvas()
+    {
+        var canvas = FindObjectOfType<Canvas>();
+        if (!canvas)
+        {
+            var go = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        }
+        return canvas;
+    }
+
+    void BuildSection(ItemSlot slot, string label)
+    {
+        var section = new GameObject($"{label}Section", typeof(RectTransform), typeof(VerticalLayoutGroup));
+        section.transform.SetParent(root, false);
+        var layout = section.GetComponent<VerticalLayoutGroup>();
+        layout.spacing = 2;
+        layout.childControlWidth = true;
+        layout.childForceExpandWidth = true;
+
+        var headerGO = new GameObject("Header", typeof(TextMeshProUGUI));
+        headerGO.transform.SetParent(section.transform, false);
+        var headerText = headerGO.GetComponent<TextMeshProUGUI>();
+        headerText.text = label;
+        _sectionHeaders[slot] = headerText;
+
+        CreateButton(section.transform, "Unequip", () => Equip(slot, null));
+
+        var items = catalog.ForSlot(slot);
+        foreach (var item in items)
+        {
+            var id = string.IsNullOrEmpty(item.Id) ? item.name : item.Id;
+            CreateButton(section.transform, id, () => Equip(slot, item));
+        }
+    }
+
+    void CreateButton(Transform parent, string label, UnityEngine.Events.UnityAction onClick)
+    {
+        var go = new GameObject(label, typeof(RectTransform), typeof(Image), typeof(Button));
+        go.transform.SetParent(parent, false);
+        var img = go.GetComponent<Image>();
+        img.color = new Color(1, 1, 1, 0.1f);
+
+        var btn = go.GetComponent<Button>();
+        btn.onClick.AddListener(onClick);
+
+        var textGO = new GameObject("Text", typeof(TextMeshProUGUI));
+        textGO.transform.SetParent(go.transform, false);
+        var tmp = textGO.GetComponent<TextMeshProUGUI>();
+        tmp.text = label;
+        tmp.alignment = TextAlignmentOptions.Center;
+        tmp.enableAutoSizing = true;
+        var rt = tmp.rectTransform;
+        rt.anchorMin = Vector2.zero;
+        rt.anchorMax = Vector2.one;
+        rt.offsetMin = Vector2.zero;
+        rt.offsetMax = Vector2.zero;
+
+        var fitter = go.AddComponent<ContentSizeFitter>();
+        fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+        fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+    }
+
+    void Equip(ItemSlot slot, ItemDef item)
+    {
+        var loadout = LoadoutStorage.Load();
+        switch (slot)
+        {
+            case ItemSlot.Head: loadout.Head = item; break;
+            case ItemSlot.Body: loadout.Body = item; break;
+            case ItemSlot.Weapon: loadout.Weapon = item; break;
+            case ItemSlot.Offhand: loadout.Offhand = item; break;
+        }
+        LoadoutStorage.Save(loadout);
+        if (presenter) presenter.Apply(loadout.Head, loadout.Body, loadout.Weapon, loadout.Offhand);
+        if (simulator) simulator.RecomputeStats(loadout);
+        UpdateHeader(slot, item);
+    }
+
+    void UpdateHeader(ItemSlot slot, ItemDef item)
+    {
+        if (_sectionHeaders.TryGetValue(slot, out var t))
+        {
+            var baseLabel = slot.ToString();
+            t.text = item ? $"{baseLabel}: {item.Id}" : baseLabel;
+        }
+    }
+}

--- a/Assets/Scripts/UI/LoadoutUI.cs.meta
+++ b/Assets/Scripts/UI/LoadoutUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbfa417e29ad4bdda5b1630f25ed7968
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/StatsReadout.cs
+++ b/Assets/Scripts/UI/StatsReadout.cs
@@ -1,0 +1,17 @@
+using TMPro;
+using UnityEngine;
+
+public class StatsReadout : MonoBehaviour
+{
+    public CombatSimulator sim;
+    public TextMeshProUGUI text;
+
+    void Update()
+    {
+        if (sim && text)
+        {
+            var dps = sim.DebugDPS();
+            text.text = $"Gold: {sim.GetGold():N0}\nDPS: {dps:F1}\nGPS: {dps * sim.goldPerDamage:F2}";
+        }
+    }
+}

--- a/Assets/Scripts/UI/StatsReadout.cs.meta
+++ b/Assets/Scripts/UI/StatsReadout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9c0efd7149d41fdbb349176260fc783
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `ItemCatalog` ScriptableObject for listing and filtering items by slot
- Provide `LoadoutUI` to build equip buttons at runtime and apply selections
- Show live gold, DPS and GPS via `StatsReadout` and enhanced `GoldHud`

## Testing
- `mcs Assets/Scripts/Combat/CombatSimulator.cs Assets/Scripts/Core/GameClock.cs Assets/Scripts/Core/SaveData.cs Assets/Scripts/Core/SaveService.cs Assets/Scripts/Items/ItemDef.cs Assets/Scripts/Items/Loadout.cs Assets/Scripts/Items/LoadoutDemo.cs Assets/Scripts/Items/LoadoutPresenter.cs Assets/Scripts/Items/LoadoutStorage.cs Assets/Scripts/Items/ItemCatalog.cs Assets/Scripts/UI/GoldHud.cs Assets/Scripts/UI/LoadoutUI.cs Assets/Scripts/UI/StatsReadout.cs Assets/Scripts/Stats/StatBlock.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1debb0c6083278d808e14824a8b7d